### PR TITLE
Feat/batch processing urls

### DIFF
--- a/Nuget_README.md
+++ b/Nuget_README.md
@@ -77,6 +77,7 @@ Add these settings to the **appsettings.json**
     "Endpoint": "https://api.cloudflare.com/client/v4/zones/[zoneId]/purge_cache",
     "Domain": "https://www.example.com",
     "EnableLogging": true, //optional
+    "PurgeBatchSize": 45, // optional => split URL lists into batches (default: 45)
     "KeyNodes": "1234, 031089", // optional
     "KeyParentNodes": "1001",  // optional
     "BlockAliases": "formBlock, otherFormBlock", // optional
@@ -181,6 +182,12 @@ By using key parent nodes, you ensure that all related cached content is correct
 
 #### **Example**
 Let’s say you have a page with ID 1242 called "News", and it lists recent news articles. If you set 1242 as a key parent node, and a new article is published under it, any page that references the "News" page (like the homepage) will also be purged from cache — keeping your site content consistent.
+
+### Batch Purging (new)
+
+CogFlare now splits large URL purge lists into smaller batches to respect Cloudflare limits (many plans allow up to 50 URLs per purge request). The default batch size is 45 URLs, which is configurable via the `PurgeBatchSize` setting in `CogFlareSettings`.
+
+ 
 
 ## Backoffice User:
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Add these settings to the **appsettings.json**
     "Endpoint": "https://api.cloudflare.com/client/v4/zones/[zoneId]/purge_cache",
     "Domain": "https://www.example.com",
     "EnableLogging": true, //optional
+    "PurgeBatchSize": 45, // optional => split URL lists into batches (default: 45)
     "KeyNodes": "1234, 031089", // optional
     "KeyParentNodes": "1001",  // optional
     "BlockAliases": "formBlock, otherFormBlock", // optional
@@ -215,6 +216,15 @@ By using key parent nodes, you ensure that all related cached content is correct
 
 ### **Example**
 Let’s say you have a page with ID 1242 called "News", and it lists recent news articles. If you set 1242 as a key parent node, and a new article is published under it, any page that references the "News" page (like the homepage) will also be purged from cache — keeping your site content consistent.
+
+## Batch Purging (new)
+
+To support Cloudflare plan limits (many plans limit purge requests to around 50 URLs per request), CogFlare now splits large purge lists into smaller batches and issues multiple purge requests as needed. This prevents Cloudflare rejecting large purge requests and helps ensure purges complete successfully.
+
+- **Default batch size:** 45 URLs per request (configurable).
+- **How to configure:** add the `PurgeBatchSize` integer value to your `CogFlareSettings` in `appsettings.json`.
+
+ 
 
 ## Backoffice User:
 

--- a/src/Cogworks.CogFlare.Core/Models/CogFlareSettings.cs
+++ b/src/Cogworks.CogFlare.Core/Models/CogFlareSettings.cs
@@ -16,6 +16,7 @@ public record CogFlareSettings
     public string CacheTimeEdge { get; init; } = string.Empty;
     public bool IsValid => ApiKey.HasValue() && Email.HasValue() && Endpoint.HasValue();
     public string AuthenticationMethod { get; init; } = string.Empty;
+    public int UrlBatchSize { get; init; } = 45;
 
     public IEnumerable<int> GetKeyNodes()
     {

--- a/src/Cogworks.CogFlare.Core/Models/PurgeSettings.cs
+++ b/src/Cogworks.CogFlare.Core/Models/PurgeSettings.cs
@@ -4,9 +4,9 @@ public record PurgeSettings
 {
     [JsonPropertyName("purge_everything")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool PurgeEverything { get; init; }
+    public bool PurgeEverything { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("files")]
-    public IEnumerable<string> Files { get; init; }
+    public IEnumerable<string> Files { get; set; }
 }

--- a/src/Cogworks.CogFlare.Core/Services/CloudFlareCachePurgeService.cs
+++ b/src/Cogworks.CogFlare.Core/Services/CloudFlareCachePurgeService.cs
@@ -46,18 +46,20 @@ public class CloudFlareCachePurgeService : ICloudFlareCachePurgeService
         else
         {
             var batchSize = _cogFlareSettings.UrlBatchSize;
-            var purgesSuccessful = false;
+            var tasks = new List<Task<bool>>();
 
-            for (var itemsProcessed = 0; itemsProcessed < urls.Count(); itemsProcessed += _cogFlareSettings.UrlBatchSize)
+            for (var itemsProcessed = 0; itemsProcessed < urls.Count(); itemsProcessed += batchSize)
             {
                 purgeSettings.Files = urls
                     .Skip(itemsProcessed)
                     .Take(batchSize);
-
-                purgesSuccessful = await SendPurgeRequest(purgeSettings, cancellationToken);
+                
+                tasks.Add(SendPurgeRequest(purgeSettings, cancellationToken));
             }
+            
+            var results = await Task.WhenAll(tasks);
 
-            return purgesSuccessful;
+            return results.All(batchSucceeded => batchSucceeded);
         }
     }
 

--- a/src/Cogworks.CogFlare.Core/Services/CloudFlareCachePurgeService.cs
+++ b/src/Cogworks.CogFlare.Core/Services/CloudFlareCachePurgeService.cs
@@ -35,10 +35,30 @@ public class CloudFlareCachePurgeService : ICloudFlareCachePurgeService
         var purgeSettings = new PurgeSettings
         {
             PurgeEverything = purgeEverything,
-            Files = purgeEverything ? null : urls
         };
 
-        return await SendPurgeRequest(purgeSettings, cancellationToken);
+        if (purgeEverything == true)
+        {
+            purgeSettings.Files = null;
+
+            return await SendPurgeRequest(purgeSettings, cancellationToken);
+        }
+        else
+        {
+            var batchSize = _cogFlareSettings.UrlBatchSize;
+            var purgesSuccessful = false;
+
+            for (var itemsProcessed = 0; itemsProcessed < urls.Count(); itemsProcessed += _cogFlareSettings.UrlBatchSize)
+            {
+                purgeSettings.Files = urls
+                    .Skip(itemsProcessed)
+                    .Take(batchSize);
+
+                purgesSuccessful = await SendPurgeRequest(purgeSettings, cancellationToken);
+            }
+
+            return purgesSuccessful;
+        }
     }
 
     private async Task<bool> SendPurgeRequest(PurgeSettings purgeSettings, CancellationToken cancellationToken)
@@ -67,7 +87,11 @@ public class CloudFlareCachePurgeService : ICloudFlareCachePurgeService
         {
             var response = await client.SendAsync(request, cancellationToken);
 
-            _logService.Log($"CloudFlare response for purging: {response.ReasonPhrase}");
+            var urlsLogMessage = purgeSettings.Files.HasAny()
+                ? $"({purgeSettings.Files.Count()}) URLs processed -"
+                : string.Empty;
+
+            _logService.Log($"{urlsLogMessage}CloudFlare response for purging: {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }

--- a/src/Cogworks.CogFlare/umbraco-marketplace-readme.md
+++ b/src/Cogworks.CogFlare/umbraco-marketplace-readme.md
@@ -76,6 +76,7 @@ Add these settings to the **appsettings.json**
     "Endpoint": "https://api.cloudflare.com/client/v4/zones/[zoneId]/purge_cache",
     "Domain": "https://www.example.com",
     "EnableLogging": true, //optional
+    "PurgeBatchSize": 45, // optional => split URL lists into batches (default: 45)
     "KeyNodes": "1234, 031089", // optional
     "KeyParentNodes": "1001",  // optional
     "BlockAliases": "formBlock, otherFormBlock", // optional
@@ -181,6 +182,12 @@ By using key parent nodes, you ensure that all related cached content is correct
 
 #### **Example**
 Let’s say you have a page with ID 1242 called "News", and it lists recent news articles. If you set 1242 as a key parent node, and a new article is published under it, any page that references the "News" page (like the homepage) will also be purged from cache — keeping your site content consistent.
+
+## Batch Purging (new)
+
+To avoid Cloudflare rejecting large purge requests (many Cloudflare plans limit purges to ~50 URLs per request), the package now splits large lists of URLs into batches and sends multiple purge requests. The default batch size is 45 URLs; change it with the `PurgeBatchSize` setting in `CogFlareSettings`.
+
+ 
 
 ## Backoffice User:
 


### PR DESCRIPTION
**Added logic for purge requests with multiple URLs to be processed in batches**:

- CloudFlare has certain restrictions on high amount of URLs to process per request, so we need to send purge requests in smaller chunks/batches

---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] My PR has a descriptive title (not a vague title like `Needed this`)
- [X] Title and all the commits follow [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [X] My PR targets the `develop` branch or appropriate `release` branch
- [X] My PR provides test coverage for my change (where applicable)
- [ ] I've placed the link to the corresponding Trello card or issue which this PR fixes/address below ⤵️

---

Fixes:

<img width="903" height="385" alt="image" src="https://github.com/user-attachments/assets/7aa3af25-4aa8-448d-82f4-2aeb99397aa4" />
